### PR TITLE
Restrict HLQ002 to enumerable interfaces

### DIFF
--- a/NetFabric.Hyperlinq.Analyzer.UnitTests/TestData/HLQ002/NoDiagnostic/Enumerable.Async.cs
+++ b/NetFabric.Hyperlinq.Analyzer.UnitTests/TestData/HLQ002/NoDiagnostic/Enumerable.Async.cs
@@ -12,10 +12,12 @@ namespace HLQ002.NoDiagnostic
              yield return await Task.FromResult(new TestType());
         }
 
+#pragma warning disable IDE0022 // Use expression body for methods
         public IAsyncEnumerable<TestType> Method()
         {
             return Method_AsyncIterator();
         }
+#pragma warning restore IDE0022 // Use expression body for methods
 
         public IAsyncEnumerable<TestType> MethodArrow() 
             => Method_AsyncIterator();

--- a/NetFabric.Hyperlinq.Analyzer.UnitTests/TestData/HLQ002/NoDiagnostic/Enumerable.cs
+++ b/NetFabric.Hyperlinq.Analyzer.UnitTests/TestData/HLQ002/NoDiagnostic/Enumerable.cs
@@ -11,12 +11,24 @@ namespace HLQ002.NoDiagnostic
             yield return new TestType();
         }
 
+#pragma warning disable IDE0022 // Use expression body for methods
         public IEnumerable<TestType> Method()
         {
             return Method_Iterator();
         }
+#pragma warning restore IDE0022 // Use expression body for methods
 
         public IEnumerable<TestType> MethodArrow() 
             => Method_Iterator();
+
+#pragma warning disable IDE0022 // Use expression body for methods
+        public string StringMethod()
+        {
+            return null;
+        }
+#pragma warning restore IDE0022 // Use expression body for methods
+
+        public string StringMethodArrow()
+            => null;
     }
 }

--- a/NetFabric.Hyperlinq.Analyzer/Analyzers/HLQ002_NullEnumerableAnalyzer.cs
+++ b/NetFabric.Hyperlinq.Analyzer/Analyzers/HLQ002_NullEnumerableAnalyzer.cs
@@ -41,7 +41,7 @@ namespace NetFabric.Hyperlinq.Analyzer
             if (!(context.Node is MethodDeclarationSyntax methodDeclarationSyntax))
                 return;
 
-            if (!methodDeclarationSyntax.ReturnsEnumerable(context))
+            if (!methodDeclarationSyntax.ReturnsEnumerableInterface(context))
                 return;
 
             if (methodDeclarationSyntax.Body is null)

--- a/NetFabric.Hyperlinq.Analyzer/Utils/MethodDeclarationSyntaxExtensions.cs
+++ b/NetFabric.Hyperlinq.Analyzer/Utils/MethodDeclarationSyntaxExtensions.cs
@@ -22,6 +22,15 @@ namespace NetFabric.Hyperlinq.Analyzer
                 || typeSymbol.IsAsyncEnumerable(context.Compilation, out var _));
         }
 
+        public static bool ReturnsEnumerableInterface(this MethodDeclarationSyntax methodDeclarationSyntax, SyntaxNodeAnalysisContext context)
+        {
+            var typeSymbol = context.SemanticModel.GetTypeInfo(methodDeclarationSyntax.ReturnType).Type;
+            return typeSymbol is object
+                && typeSymbol.TypeKind == TypeKind.Interface
+                && (typeSymbol.IsEnumerable(context.Compilation, out var _)
+                || typeSymbol.IsAsyncEnumerable(context.Compilation, out var _));
+        }
+
         public static bool IsExtensionMethod(this MethodDeclarationSyntax methodDeclarationSyntax, [NotNullWhen(true)] out ParameterSyntax? parameterSyntax)
         {
             var parameters = methodDeclarationSyntax.ParameterList.Parameters;


### PR DESCRIPTION
There are cases where methods that return an enumerable but this is not exactly their main purpose. For example, `string`.
This PR limits the rule to return types that are interfaces and are explicitly enumerables, for example, `IEnumerable<>`, `IReadOnlyCollection`, or `IReadOnlyList` and also interfaces that derive from these.
 