### PR TITLE
Include NetFabric.CodeAnalysis

### DIFF
--- a/NetFabric.Hyperlinq.Analyzer.Package/NetFabric.Hyperlinq.Analyzer.Package.csproj
+++ b/NetFabric.Hyperlinq.Analyzer.Package/NetFabric.Hyperlinq.Analyzer.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>NetFabric.Hyperlinq.Analyzer</PackageId>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <Authors>Antao Almada</Authors>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -21,7 +21,7 @@
     <PackageTags>hyperlinq, analyzers, enumerable, async, linq, performance</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
@@ -41,6 +41,7 @@
 
   <Target Name="_AddAnalyzersToOutput">
     <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\NetFabric.CodeAnalysis.dll" PackagePath="analyzers/dotnet/cs" />
       <TfmSpecificPackageFile Include="$(OutputPath)\NetFabric.Hyperlinq.Analyzer.dll" PackagePath="analyzers/dotnet/cs" />
       <TfmSpecificPackageFile Include="$(OutputPath)\NetFabric.Hyperlinq.Analyzer.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>

--- a/NetFabric.Hyperlinq.Analyzer/NetFabric.Hyperlinq.Analyzer.csproj
+++ b/NetFabric.Hyperlinq.Analyzer/NetFabric.Hyperlinq.Analyzer.csproj
@@ -6,8 +6,7 @@
     <LangVersion>10</LangVersion>
     <EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
     
-    <!-- Avoid ID conflicts with the package project. -->
-    <PackageId>*$(MSBuildProjectFile)*</PackageId>
+    <PackageId>NetFabric.Hyperlinq.Analyzer</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

I want to mention that I do not have any experience with nuget packages that have dependencies. I quickly tried to fix the issue myself.

The dependency on NetFabric.CodeAnalysis is lost due the use of `SuppressDependenciesWhenPacking`. When setting that to true the dependency will appear in the .nupkg. There is a separate project for the file creating the package, but that package id is the same as the project where the analyzers are living in. The `$(MSBuildProjectFile)*` was throwing an error, so I changed that to Dummy. Because there are two projects however the Package will also consider the referenced project as a dependency of the nuget package which is not ok. I did briefly explore the possibility to merge the contents of the ` .Package`. together with the actual analyzers project but this would be a huge refactor.

Instead I came up with this workaround:
* CopyLocalLockFileAssemblies will copy a number of assemblies to the bin directory of the package. It seems a bit ugly, but that seems to work.
* Include NetFabric.CodeAnalysis in the package (via TfmSpecificPackageFile)
* Rectify the build error on PackageId containing invalid characters (`*$(MSBuildProjectFile)*`)

This should hopefully fix #73 